### PR TITLE
Expose main package as root

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ SIWE provides a `SiweMessage` class which implements EIP-4361.
 Parsing is done by initializing a `SiweMessage` object with an EIP-4361 formatted string:
 
 ``` python
+from siwe import SiweMessage
 message: SiweMessage = SiweMessage(message=eip_4361_string)
 ```
 

--- a/siwe/__init__.py
+++ b/siwe/__init__.py
@@ -1,0 +1,1 @@
+from .siwe import *

--- a/siwe/__init__.py
+++ b/siwe/__init__.py
@@ -1,1 +1,12 @@
-from .siwe import *
+# flake8: noqa: F401
+from .siwe import (
+    SiweMessage,
+    VerificationError,
+    InvalidSignature,
+    ExpiredMessage,
+    NotYetValidMessage,
+    DomainMismatch,
+    NonceMismatch,
+    MalformedSession,
+    generate_nonce,
+)


### PR DESCRIPTION
I didn't realise the main module was namespaced, with this change it should allow everyone to do `from siwe import ...`