### PR TITLE
fix CustomDateTime issue

### DIFF
--- a/siwe/siwe.py
+++ b/siwe/siwe.py
@@ -108,7 +108,7 @@ class CustomDateTime(str):
     @classmethod
     def validate(cls, v: str):
         """Validate the format."""
-        cls.date = isoparse(v)
+        isoparse(v)
         return cls(v)
 
 
@@ -268,10 +268,10 @@ class SiweMessage(BaseModel):
         verification_time = datetime.now(UTC) if timestamp is None else timestamp
         if (
             self.expiration_time is not None
-            and verification_time >= self.expiration_time.date
+            and verification_time >= isoparse(self.expiration_time)
         ):
             raise ExpiredMessage()
-        if self.not_before is not None and verification_time <= self.not_before.date:
+        if self.not_before is not None and verification_time <= isoparse(self.not_before):
             raise NotYetValidMessage()
 
         try:


### PR DESCRIPTION
It appears that the current implementation of the `CustomDateTime` class  has a problem when used with certain date-time formats. I've observed this issue when running the following test code:

```python
from siwe import SiweMessage

message = {
    'domain': 'localhost:3000',
    'statement': 'Sign in with Ethereum to the app.',
    'uri': 'http://localhost:3000',
    'version': '1',
    'chain_id': 1,
    'nonce': 12345678,
    'not_before': '2023-09-28T14:35:42.031383+08:00',
    'address': '0x0000000000000000000000000000000000000000',
    'expiration_time': '2023-09-30T14:35:42.035047+08:00',
    'issued_at': '2023-09-28T14:35:42.035060+08:00'
}

siwe_message = SiweMessage(message)
print(siwe_message.expiration_time)
print(siwe_message.expiration_time.date)

# output:
# 2023-09-30T14:35:42.035047+08:00
# 2023-09-28 14:35:42.031383+08:00 (incorrect)
