### PR TITLE
Fix Safe wallet signature verification

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "siwe"
-version = "4.3.1"
+version = "4.4.0"
 description = "A Python implementation of Sign-In with Ethereum (EIP-4361)."
 license = "MIT OR Apache-2.0"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "siwe"
-version = "4.3.0"
+version = "4.3.1"
 description = "A Python implementation of Sign-In with Ethereum (EIP-4361)."
 license = "MIT OR Apache-2.0"
 authors = [

--- a/siwe/siwe.py
+++ b/siwe/siwe.py
@@ -355,8 +355,8 @@ def check_contract_wallet_signature(
     contract = w3.eth.contract(address=address, abi=EIP1271_CONTRACT_ABI)
     hash_ = _hash_eip191_message(message)
     try:
-        # Signatures returned from Safe wallets are always "0x" and should be
-        # passed in as-is.
+        # For message hashes stored on-chain for Safe wallets, the signatures
+        # are always "0x" and should be passed in as-is.
         response = contract.caller.isValidSignature(
             hash_, signature if signature == "0x" else bytes.fromhex(signature[2:])
         )

--- a/tests/test_siwe.py
+++ b/tests/test_siwe.py
@@ -94,6 +94,13 @@ class TestMessageVerification:
         siwe_message = SiweMessage.from_message(message=test["message"])
         siwe_message.verify(test["signature"], provider=provider)
 
+    def test_safe_wallet_message(self):
+        message = "localhost:3000 wants you to sign in with your Ethereum account:\n0x54D97AEa047838CAC7A9C3e452951647f12a440c\n\nPlease sign in to verify your ownership of this wallet\n\nURI: http://localhost:3000\nVersion: 1\nChain ID: 11155111\nNonce: gDj8rv7VVxN\nIssued At: 2024-10-10T08:34:03.152Z\nExpiration Time: 2024-10-13T08:34:03.249112Z"
+        signature = "0x"
+        provider = HTTPProvider(endpoint_uri=endpoint_uri)
+        siwe_message = SiweMessage.from_message(message=message)
+        siwe_message.verify(signature, provider=provider)
+
     @pytest.mark.parametrize(
         "provider", [HTTPProvider(endpoint_uri=endpoint_uri), None]
     )

--- a/tests/test_siwe.py
+++ b/tests/test_siwe.py
@@ -97,7 +97,9 @@ class TestMessageVerification:
     def test_safe_wallet_message(self):
         message = "localhost:3000 wants you to sign in with your Ethereum account:\n0x54D97AEa047838CAC7A9C3e452951647f12a440c\n\nPlease sign in to verify your ownership of this wallet\n\nURI: http://localhost:3000\nVersion: 1\nChain ID: 11155111\nNonce: gDj8rv7VVxN\nIssued At: 2024-10-10T08:34:03.152Z\nExpiration Time: 2024-10-13T08:34:03.249112Z"
         signature = "0x"
-        provider = HTTPProvider(endpoint_uri=endpoint_uri)
+        # Use a Sepolia RPC node since the signature is generated on Sepolia testnet
+        # instead of mainnet like other EIP-1271 tests.
+        provider = HTTPProvider(endpoint_uri="https://rpc.sepolia.org")
         siwe_message = SiweMessage.from_message(message=message)
         siwe_message.verify(signature, provider=provider)
 

--- a/tests/test_siwe.py
+++ b/tests/test_siwe.py
@@ -23,10 +23,20 @@ with open(BASE_TESTS + "verification_positive.json", "r") as f:
 with open(BASE_TESTS + "eip1271.json", "r") as f:
     verification_eip1271 = decamelize(json.load(fp=f))
 
+endpoint_uri = "https://cloudflare-eth.com"
 try:
-    endpoint_uri = os.environ["WEB3_PROVIDER_URI"]
+    uri = os.environ["WEB3_PROVIDER_URI"]
+    if uri != "":
+        endpoint_uri = uri
 except KeyError:
-    endpoint_uri = "https://cloudflare-eth.com"
+    pass
+sepolia_endpoint_uri = "https://rpc.sepolia.org"
+try:
+    uri = os.environ["WEB3_PROVIDER_URI_SEPOLIA"]
+    if uri != "":
+        sepolia_endpoint_uri = uri
+except KeyError:
+    pass
 
 
 class TestMessageParsing:
@@ -99,7 +109,7 @@ class TestMessageVerification:
         signature = "0x"
         # Use a Sepolia RPC node since the signature is generated on Sepolia testnet
         # instead of mainnet like other EIP-1271 tests.
-        provider = HTTPProvider(endpoint_uri="https://rpc.sepolia.org")
+        provider = HTTPProvider(endpoint_uri=sepolia_endpoint_uri)
         siwe_message = SiweMessage.from_message(message=message)
         siwe_message.verify(signature, provider=provider)
 


### PR DESCRIPTION
The current implementation doesn't work for Safe wallets for a couple of reasons:
1. Safe wallets always return `0x` as the signature, which would cause an `IndexError` when calling `recover_message`. Since only `ValueError` is being caught, the exception would bubble up and cause a failure.
2. The signature `0x` has to be passed into the `isValidSignature` function as-is, but an empty string is currently being passed in due to `signature[2:]`.
3. The wallet contract raises a `ContractLogicError` if the signature is invalid, but it's not caught, which also causes an eventual failure.